### PR TITLE
Fix/issue 16

### DIFF
--- a/src/core/createCalendarInfo.ts
+++ b/src/core/createCalendarInfo.ts
@@ -51,5 +51,8 @@ function getWeeksInMonth(date: Date, weekStartsOn: WeekDayType) {
 }
 
 function getCurrentWeekIndex(day: number, startWeekdayInMonth: number) {
-  return Math.floor((day + startWeekdayInMonth) / 7)
+  if ((day + startWeekdayInMonth) % 7) {
+    return Math.floor((day + startWeekdayInMonth) / 7)
+  }
+  return Math.floor((day + startWeekdayInMonth) / 7) - 1
 }

--- a/src/core/createCalendarInfo.ts
+++ b/src/core/createCalendarInfo.ts
@@ -48,7 +48,11 @@ function getWeeksInMonth(date: Date, weekStartsOn: WeekDayType) {
   const monthStartsAt = (startOfMonth(date).getDay() - weekStartsOn) % 7
   const totalDaysOfMonth = getDaysInMonth(new Date(year, month))
 
-  return Math.ceil(((monthStartsAt < 0 ? monthStartsAt + 7 : monthStartsAt) + totalDaysOfMonth) / 7)
+  return Math.ceil(
+    ((monthStartsAt < 0 ? monthStartsAt + 7 : monthStartsAt) +
+      totalDaysOfMonth) /
+      7,
+  )
 }
 
 function getCurrentWeekIndex(day: number, startWeekdayInMonth: number) {

--- a/src/core/createCalendarInfo.ts
+++ b/src/core/createCalendarInfo.ts
@@ -45,10 +45,10 @@ function getStartWeekdayInMonth(date: Date, weekStartsOn: WeekDayType) {
 
 function getWeeksInMonth(date: Date, weekStartsOn: WeekDayType) {
   const { year, month } = parseDate(date)
-  const monthStartsAt = startOfMonth(date)
+  const monthStartsAt = (startOfMonth(date).getDay() - weekStartsOn) % 7
   const totalDaysOfMonth = getDaysInMonth(new Date(year, month))
 
-  return Math.ceil((monthStartsAt.getDay() + totalDaysOfMonth) / 7)
+  return Math.ceil(((monthStartsAt < 0 ? monthStartsAt + 7 : monthStartsAt) + totalDaysOfMonth) / 7)
 }
 
 function getCurrentWeekIndex(day: number, startWeekdayInMonth: number) {

--- a/src/core/createCalendarInfo.ts
+++ b/src/core/createCalendarInfo.ts
@@ -54,5 +54,6 @@ function getCurrentWeekIndex(day: number, startWeekdayInMonth: number) {
   if ((day + startWeekdayInMonth) % 7) {
     return Math.floor((day + startWeekdayInMonth) / 7)
   }
+
   return Math.floor((day + startWeekdayInMonth) / 7) - 1
 }

--- a/src/core/createCalendarInfo.ts
+++ b/src/core/createCalendarInfo.ts
@@ -44,10 +44,11 @@ function getStartWeekdayInMonth(date: Date, weekStartsOn: WeekDayType) {
 }
 
 function getWeeksInMonth(date: Date, weekStartsOn: WeekDayType) {
-  const { month } = parseDate(date)
-  const totalDaysOfMonth = getDaysInMonth(month)
+  const { year, month } = parseDate(date)
+  const monthStartsAt = startOfMonth(date)
+  const totalDaysOfMonth = getDaysInMonth(new Date(year, month))
 
-  return Math.ceil((weekStartsOn + totalDaysOfMonth) / 7)
+  return Math.ceil((monthStartsAt.getDay() + totalDaysOfMonth) / 7)
 }
 
 function getCurrentWeekIndex(day: number, startWeekdayInMonth: number) {

--- a/src/core/createCalendarInfo.ts
+++ b/src/core/createCalendarInfo.ts
@@ -44,8 +44,7 @@ function getStartWeekdayInMonth(date: Date, weekStartsOn: WeekDayType) {
 }
 
 function getWeeksInMonth(date: Date, startWeekdayInMonth: number) {
-  const { year, month } = parseDate(date)
-  const totalDaysOfMonth = getDaysInMonth(new Date(year, month))
+  const totalDaysOfMonth = getDaysInMonth(date)
 
   return Math.ceil((startWeekdayInMonth + totalDaysOfMonth) / 7)
 }

--- a/src/core/createCalendarInfo.ts
+++ b/src/core/createCalendarInfo.ts
@@ -9,7 +9,7 @@ export default function createCalendarInfo(
 ) {
   const { year, month, day } = parseDate(cursorDate)
   const startWeekdayInMonth = getStartWeekdayInMonth(cursorDate, weekStartsOn)
-  const weeksInMonth = getWeeksInMonth(cursorDate, weekStartsOn)
+  const weeksInMonth = getWeeksInMonth(cursorDate, startWeekdayInMonth)
   const weekendDays = arrayOf(7).map((index) => ({
     value: setDay(cursorDate, (index + weekStartsOn) % 7),
   }))
@@ -43,16 +43,11 @@ function getStartWeekdayInMonth(date: Date, weekStartsOn: WeekDayType) {
   return monthStartsAt < 0 ? monthStartsAt + 7 : monthStartsAt
 }
 
-function getWeeksInMonth(date: Date, weekStartsOn: WeekDayType) {
+function getWeeksInMonth(date: Date, startWeekdayInMonth: number) {
   const { year, month } = parseDate(date)
-  const monthStartsAt = (startOfMonth(date).getDay() - weekStartsOn) % 7
   const totalDaysOfMonth = getDaysInMonth(new Date(year, month))
 
-  return Math.ceil(
-    ((monthStartsAt < 0 ? monthStartsAt + 7 : monthStartsAt) +
-      totalDaysOfMonth) /
-      7,
-  )
+  return Math.ceil((startWeekdayInMonth + totalDaysOfMonth) / 7)
 }
 
 function getCurrentWeekIndex(day: number, startWeekdayInMonth: number) {


### PR DESCRIPTION
[BUG] Next and Prev button doesn't work properly at DayView. #16

```js
function getCurrentWeekIndex(day: number, startWeekdayInMonth: number) {
  if ((day + startWeekdayInMonth) % 7) {
    return Math.floor((day + startWeekdayInMonth) / 7)
  }

  return Math.floor((day + startWeekdayInMonth) / 7) - 1
}
```