### PR TITLE
refactor(utils): isSameMonth naming and importing code at test file

### DIFF
--- a/src/plugins/withDateProps.ts
+++ b/src/plugins/withDateProps.ts
@@ -1,12 +1,12 @@
 import { getDate } from 'date-fns'
 
 import { DateCell } from '../models'
-import { isSameDate, isSameMonth } from '../utils'
+import { isSameDate, isSameYearAndMonth } from '../utils'
 
 export default function withDateProps(baseDate: Date, cursorDate: Date) {
   return function <T extends DateCell>(cell: T) {
     const { value: targetDate } = cell
-    const isCurrentMonth = isSameMonth(cursorDate, targetDate)
+    const isCurrentMonth = isSameYearAndMonth(cursorDate, targetDate)
     const isCurrentDate = isSameDate(baseDate, targetDate)
 
     return {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 export { default as arrayOf } from './arrayOf'
 export { default as generateID } from './generateID'
 export { default as isSameDate } from './isSameDate'
-export { default as isSameMonth } from './isSameMonth'
+export { default as isSameYearAndMonth } from './isSameYearAndMonth'
 export { default as parseDate } from './parseDate'
 export * from './pipe'
 export { default as withKey } from './withKey'

--- a/src/utils/isSameYearAndMonth.test.ts
+++ b/src/utils/isSameYearAndMonth.test.ts
@@ -1,12 +1,12 @@
-import { isSameMonth } from 'date-fns'
+import isSameYearAndMonth from './isSameYearAndMonth'
 
-describe('isSameMonth function', () => {
+describe('isSameYearAndMonth function', () => {
   it('return true', () => {
     // Given
     const baseDate = new Date(2020, 11, 27)
     const targetDate1 = new Date(2020, 11, 22)
     // When
-    const result1 = isSameMonth(baseDate, targetDate1)
+    const result1 = isSameYearAndMonth(baseDate, targetDate1)
     // Then
     expect(result1).toBeTruthy()
   })
@@ -18,9 +18,9 @@ describe('isSameMonth function', () => {
     const targetDate2 = new Date(2020, 10, 27)
     const targetDate3 = new Date(2021, 10, 27)
     // When
-    const result1 = isSameMonth(baseDate, targetDate1)
-    const result2 = isSameMonth(baseDate, targetDate2)
-    const result3 = isSameMonth(baseDate, targetDate3)
+    const result1 = isSameYearAndMonth(baseDate, targetDate1)
+    const result2 = isSameYearAndMonth(baseDate, targetDate2)
+    const result3 = isSameYearAndMonth(baseDate, targetDate3)
     // Then
     expect(result1).toBeFalsy()
     expect(result2).toBeFalsy()

--- a/src/utils/isSameYearAndMonth.ts
+++ b/src/utils/isSameYearAndMonth.ts
@@ -1,5 +1,5 @@
 import { isSameMonth as _isSameMonth, isSameYear } from 'date-fns'
 
-export default function isSameMonth(baseDate: Date, targetDate: Date) {
+export default function isSameYearAndMonth(baseDate: Date, targetDate: Date) {
   return _isSameMonth(targetDate, baseDate) && isSameYear(targetDate, baseDate)
 }


### PR DESCRIPTION
- The year must match, so `isSameYearAndMonth` matches.
