### PR TITLE
ci(releasrc): remove asset at semantic-release/github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - alpha
+      - beta
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build Package
         run: yarn build
       - name: Release to npm registry
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,14 +12,13 @@
     "@semantic-release/npm",
     [
       "@semantic-release/github", {
-        "assets": ["dist/*", "esm/*", "package.json"],
         "successComment": "🎉 This PR is included in version ${nextRelease.version} 🎉 "
       }
     ],
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json", "yarn.lock"],
+        "assets": ["package.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]


### PR DESCRIPTION
## Description

> related issue: #22 

once `semantic-release/git` push draft release with `asset`, `semantic-release/github`'s asset is considered a duplicate asset.

remove this.

and add pre-release branch(alpha, beta) to release action traget.

## References