### PR TITLE
fix(docs): Update example docs

### DIFF
--- a/docs/src/examples/basic.mdx
+++ b/docs/src/examples/basic.mdx
@@ -7,7 +7,7 @@ fullpage: true
 
 # Basic
 
-react-calendar basic example (with Charkra UI)
+react-calendar basic example (with Chakra UI)
 
 - [View Source](https://github.com/veccu/react-calendar/tree/main/examples/basic)
 


### PR DESCRIPTION
This just fixes the word `Charkra` for `Chakra`.