### PR TITLE
fix: Remove remainder % 7 from weekendDays

### DIFF
--- a/src/core/createCalendarInfo.ts
+++ b/src/core/createCalendarInfo.ts
@@ -11,7 +11,7 @@ export default function createCalendarInfo(
   const startWeekdayInMonth = getStartWeekdayInMonth(cursorDate, weekStartsOn)
   const weeksInMonth = getWeeksInMonth(cursorDate, startWeekdayInMonth)
   const weekendDays = arrayOf(7).map((index) => ({
-    value: setDay(cursorDate, (index + weekStartsOn) % 7),
+    value: setDay(cursorDate, index + weekStartsOn),
   }))
 
   const getDateCellByIndex = (weekIndex: number, dayIndex: number) => {

--- a/src/useCalendar.test.ts
+++ b/src/useCalendar.test.ts
@@ -47,6 +47,57 @@ describe('useCalendar hooks test', () => {
       }))
       expect(onlyDates).toEqual([{ value: defaultDate }])
     })
+
+    it('return weekDays when set WeekDayType: 0', () => {
+      // Given
+      const defaultDate = new Date(2021, 8, 30)
+      const defaultWeekStart = 0
+      // When
+      const { result } = renderHook(() =>
+        useCalendar({
+          defaultDate,
+          defaultWeekStart,
+        }),
+      )
+      // Then
+      const onlyDates = result.current.headers.weekDays.map(({ value }) => ({
+        value,
+      }))
+      expect(onlyDates).toEqual([
+        { value: new Date(2021, 8, 26) },
+        { value: new Date(2021, 8, 27) },
+        { value: new Date(2021, 8, 28) },
+        { value: new Date(2021, 8, 29) },
+        { value: new Date(2021, 8, 30) },
+        { value: new Date(2021, 9, 1) },
+        { value: new Date(2021, 9, 2) },
+      ])
+    })
+    it('return weekDays when set WeekDayType: 1', () => {
+      // Given
+      const defaultDate = new Date(2021, 8, 30)
+      const defaultWeekStart = 1
+      // When
+      const { result } = renderHook(() =>
+        useCalendar({
+          defaultDate,
+          defaultWeekStart,
+        }),
+      )
+      // Then
+      const onlyDates = result.current.headers.weekDays.map(({ value }) => ({
+        value,
+      }))
+      expect(onlyDates).toEqual([
+        { value: new Date(2021, 8, 27) },
+        { value: new Date(2021, 8, 28) },
+        { value: new Date(2021, 8, 29) },
+        { value: new Date(2021, 8, 30) },
+        { value: new Date(2021, 9, 1) },
+        { value: new Date(2021, 9, 2) },
+        { value: new Date(2021, 9, 3) },
+      ])
+    })
   })
 
   describe('result.body', () => {


### PR DESCRIPTION
## Description
As #85 said, there a bug with headers.weekDays when use none zero WeekDayType.
- Remove remainder % 7 logic in createCalendarInfo and then add test for it.

> related issue: #85 